### PR TITLE
#8 Relax lower bound on aeson

### DIFF
--- a/smoothie.cabal
+++ b/smoothie.cabal
@@ -37,7 +37,7 @@ library
   build-depends:       base   >= 4.7  && < 5.0
                      , linear >= 1.16 && < 1.20
                      , vector >= 0.10 && < 0.12
-                     , aeson  >= 0.9  && < 0.10
+                     , aeson  >= 0.8  && < 0.10
                      , text   >= 1.2  && < 1.3
 
   hs-source-dirs:      src


### PR DESCRIPTION
I've tested that this builds successfully against aeson-0.8.0.2. I've also looked at the FromJSON and ToJSON instances and I'm unaware of anything that would be affected by using the older aeson.

(I'm not sure what the diff is on the version and description lines, I just made this PR through the github edit UI.)